### PR TITLE
Effect whitelist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         </repository>
         <repository>
             <id>codemc-repo</id>
-            <url>https://repo.codemc.org/repository/maven-public/</url>
+            <url>https://repo.codemc.io/repository/maven-public/</url>
             <layout>default</layout>
         </repository>
         <repository>
@@ -30,6 +30,10 @@
         <repository>
             <id>sk89q</id>
             <url>http://maven.sk89q.com/repo/</url>
+        </repository>
+        <repository>
+            <id>minevolt</id>
+            <url>https://minevolt.net/repo/</url>
         </repository>
     </repositories>
 

--- a/src/main/java/org/openredstone/patch/DeathPotionsPatch.java
+++ b/src/main/java/org/openredstone/patch/DeathPotionsPatch.java
@@ -101,13 +101,14 @@ public class DeathPotionsPatch extends Patch implements Listener {
 
     private boolean hasLegalEffects(List<PotionEffect> potionEffects) {
         for (PotionEffect effect : potionEffects) {
-            if(!safeEffectsSet.contains(effect.getType())) {
-                if (effect.getType().equals(PotionEffectType.HEAL) && (effect.getAmplifier() > maxAmplifier)) {
-                    return false;
-                }
-                if (effect.getDuration() > maxDuration) {
-                    return false;
-                }
+            if (safeEffectsSet.contains(effect.getType())) {
+                continue;
+            }
+            if (effect.getType().equals(PotionEffectType.HEAL) && (effect.getAmplifier() > maxAmplifier)) {
+                return false;
+            }
+            if (effect.getDuration() > maxDuration) {
+                return false;
             }
         }
         return true;

--- a/src/main/java/org/openredstone/patch/DeathPotionsPatch.java
+++ b/src/main/java/org/openredstone/patch/DeathPotionsPatch.java
@@ -13,12 +13,51 @@ import org.bukkit.potion.PotionEffectType;
 import org.openredstone.PatchORE;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 public class DeathPotionsPatch extends Patch implements Listener {
 
     private int maxAmplifier = PatchORE.config.getInt("deathpotions.max_amplifier");
     private int maxDuration = PatchORE.config.getInt("deathpotions.max_duration");
+
+    private final HashSet<PotionEffectType> safeEffectsSet = new HashSet<>(Arrays.asList(
+        //PotionEffectType.POISON,
+        //PotionEffectType.WITHER,
+        //PotionEffectType.HEALTH_BOOST,
+        //PotionEffectType.ABSORPTION,
+        //PotionEffectType.HEAL,
+        //PotionEffectType.HARM,
+        //PotionEffectType.REGENERATION,
+
+        //PotionEffectType.INCREASE_DAMAGE,
+        //PotionEffectType.SPEED,
+        //PotionEffectType.DOLPHINS_GRACE,
+        //PotionEffectType.CONFUSION,
+        PotionEffectType.SLOW,
+        PotionEffectType.FAST_DIGGING,
+        PotionEffectType.SLOW_DIGGING,
+        PotionEffectType.JUMP,
+        PotionEffectType.DAMAGE_RESISTANCE,
+        PotionEffectType.FIRE_RESISTANCE,
+        PotionEffectType.WATER_BREATHING,
+        PotionEffectType.INVISIBILITY,
+        PotionEffectType.BLINDNESS,
+        PotionEffectType.NIGHT_VISION,
+        PotionEffectType.HUNGER,
+        PotionEffectType.WEAKNESS,
+        PotionEffectType.SATURATION,
+        PotionEffectType.GLOWING,
+        PotionEffectType.LEVITATION,
+        PotionEffectType.LUCK,
+        PotionEffectType.UNLUCK,
+        PotionEffectType.SLOW_FALLING,
+        PotionEffectType.CONDUIT_POWER,
+        PotionEffectType.BAD_OMEN,
+        PotionEffectType.HERO_OF_THE_VILLAGE
+    ));
+
 
     public DeathPotionsPatch(JavaPlugin plugin) {
         super(plugin);
@@ -62,11 +101,13 @@ public class DeathPotionsPatch extends Patch implements Listener {
 
     private boolean hasLegalEffects(List<PotionEffect> potionEffects) {
         for (PotionEffect effect : potionEffects) {
-            if (effect.getType().equals(PotionEffectType.HEAL) && (effect.getAmplifier() > maxAmplifier)) {
-                return false;
-            }
-            if (effect.getDuration() > maxDuration) {
-                return false;
+            if(!safeEffectsSet.contains(effect.getType())) {
+                if (effect.getType().equals(PotionEffectType.HEAL) && (effect.getAmplifier() > maxAmplifier)) {
+                    return false;
+                }
+                if (effect.getDuration() > maxDuration) {
+                    return false;
+                }
             }
         }
         return true;


### PR DESCRIPTION
Adds a whitelist to allow some types of potion effects to not be subjected to filtering (as in, these effects are allowed at any duration and strength).
Whitelist instead of blacklist because it's possible that new harmful effects could be added in a future Minecraft version.
I haven't tested these changes, but I'm confident there's nothing wrong with them. They should be a complete drop-in.


The list is currently set up the way I think it should go, but you can change it of course.
Effects currently not on the list include:
- any that affect health or damage
- any that increase speed (we don't want people going around with speed 200, and we already have a way for people to increase their speed permanently)
- nausea

Everything on the safe list is an effect that does not have any impact on a creative player's ability to open their inventory and drink a bucket of milk. The worst ones are only mildly annoying.

Potential future additions could be:
- Tell the player what the problematic effect was in the filter message
- Have a config that allows different effects to be allowed.